### PR TITLE
Add pyproject for modern packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ Collection of machine learning and natural language processing utilities.
 ## Installation
 ### Dependencies
 ### User installation
+Install the package with `pip` using the included `pyproject.toml`.
+
+```bash
+pip install .
+```
+
+For development installs use the editable flag:
+
+```bash
+pip install -e .
+```
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tactictoolkit"
+version = "0.1.0"
+description = "Collection of machine learning and natural language processing utilities."
+readme = "README.md"
+license = {file = "LICENSE"}
+authors = [{name = "Ryan Little"}]
+requires-python = ">=3.8"
+dependencies = [
+    "numpy",
+    "scikit-learn",
+    "gensim",
+    "pandas",
+    "matplotlib",
+    "nltk",
+    "theano",
+]
+
+[tool.setuptools.packages.find]
+include = ["ttk*"]


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` based on setuptools
- document installation using the new build system

## Testing
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'nltk')*